### PR TITLE
[REFACTOR] 멘토 정보, 멘토 정보 수정 RequestDto수정 및 파일 첨부 동작 변경

### DIFF
--- a/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
+++ b/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
@@ -8,22 +8,19 @@ import com.dementor.domain.mentor.dto.response.*;
 import com.dementor.domain.mentor.exception.MentorException;
 import com.dementor.domain.mentor.repository.MentorRepository;
 import com.dementor.domain.mentor.service.MentorService;
-import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
+import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentResponse;
 import com.dementor.domain.mentorapplyproposal.repository.MentorApplyProposalRepository;
 import com.dementor.domain.mentoreditproposal.dto.MentorEditProposalRequest;
 import com.dementor.domain.mentoreditproposal.dto.MentorEditUpdateRenewalResponse;
-import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoringclass.service.MentoringClassService;
 import com.dementor.domain.postattachment.exception.PostAttachmentException;
 import com.dementor.domain.postattachment.service.PostAttachmentService;
 import com.dementor.global.ApiResponse;
 import com.dementor.global.security.CustomUserDetails;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -68,15 +65,10 @@ public class MentorController {
 					.body(ApiResponse.of(false, HttpStatus.BAD_REQUEST, "파일 또는 마크다운 텍스트 중 하나는 필수입니다."));
 			}
 
-			MentorApplyProposal mentorApplyProposal = mentorService.applyMentor(requestDto);
-
-			// 일반 파일 업로드
-			if (files != null && !files.isEmpty()) {
-				postAttachmentService.uploadFilesApply(files, mentorApplyProposal);
-			}
+			ApplymentResponse response = mentorService.applyMentor(requestDto, files);
 
 			return ResponseEntity.status(HttpStatus.CREATED)
-				.body(ApiResponse.of(true, HttpStatus.CREATED, "멘토 지원에 성공했습니다."));
+				.body(ApiResponse.of(true, HttpStatus.CREATED, "멘토 지원에 성공했습니다.", response));
 		} catch (MentorException e) {
 			return ResponseEntity.status(e.getErrorCode().getStatus())
 				.body(ApiResponse.of(false, e.getErrorCode().getStatus(), e.getMessage()));
@@ -118,14 +110,7 @@ public class MentorController {
 					.body(ApiResponse.of(false, HttpStatus.BAD_REQUEST, "파일 또는 마크다운 텍스트 중 하나는 필수입니다."));
 			}
 
-			MentorEditProposal mentorEditProposal = mentorService.updateMentor(memberId, requestDto);
-
-			// 일반 파일 업로드
-			if (files != null && !files.isEmpty()) {
-				postAttachmentService.uploadFilesEdit(files, mentorEditProposal);
-			}
-
-			MentorEditUpdateRenewalResponse response = MentorEditUpdateRenewalResponse.from(mentorEditProposal);
+			MentorEditUpdateRenewalResponse response = mentorService.updateMentor(memberId, requestDto, files);
 
 			return ResponseEntity.ok()
 				.body(ApiResponse.of(true, HttpStatus.OK, "멘토 정보 수정 요청에 성공했습니다.", response));

--- a/src/main/java/com/dementor/domain/mentor/dto/request/MentorApplyProposalRequest.java
+++ b/src/main/java/com/dementor/domain/mentor/dto/request/MentorApplyProposalRequest.java
@@ -2,8 +2,6 @@ package com.dementor.domain.mentor.dto.request;
 
 import jakarta.validation.constraints.*;
 
-import java.util.List;
-
 public class MentorApplyProposalRequest {
 	public record MentorApplyProposalRequestDto(
 		@NotNull(message = "회원 ID는 필수 입력 항목입니다.")
@@ -35,9 +33,7 @@ public class MentorApplyProposalRequest {
 
 		@NotBlank(message = "소개글은 필수 입력 항목입니다.")
 		@Size(max = 500, message = "자기소개는 500자 이내로 입력해주세요.")
-		String introduction,
-
-		List<Long> attachmentId
+		String introduction
 	) {
 	}
 }

--- a/src/main/java/com/dementor/domain/mentor/entity/Mentor.java
+++ b/src/main/java/com/dementor/domain/mentor/entity/Mentor.java
@@ -57,7 +57,7 @@ public class Mentor {
 	@Email
 	private String email;
 
-	@Column(nullable = false)
+	@Column(length = 500, nullable = false)
 	private String introduction;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditProposalRequest.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditProposalRequest.java
@@ -1,13 +1,10 @@
 package com.dementor.domain.mentoreditproposal.dto;
 
 import com.dementor.domain.mentor.entity.Mentor;
-
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -23,8 +20,6 @@ public class MentorEditProposalRequest {
 
 	@Size(max = 500, message = "자기소개는 500자 이내로 입력해주세요.")
 	String introduction;
-
-	List<Long> attachmentId;
 
 	public boolean hasChanges(Mentor mentor) {
 		return (career != null && !career.equals(mentor.getCareer())) ||

--- a/src/main/java/com/dementor/domain/postattachment/entity/PostAttachment.java
+++ b/src/main/java/com/dementor/domain/postattachment/entity/PostAttachment.java
@@ -40,7 +40,6 @@ public class PostAttachment extends BaseEntity {
 	@JoinColumn(name = "mentor_modification_id")
 	private MentorEditProposal mentorEditProposal;
 
-	// 예: 마크다운에서 ![alt](/images/abc123.png) 형태로 참조할 때 abc123이 uniqueIdentifier . UUID 형식 추천
 	@Column(unique = true)
 	private String uniqueIdentifier; // 마크다운 내 이미지 참조를 위한 고유 식별자
 
@@ -52,15 +51,5 @@ public class PostAttachment extends BaseEntity {
 			return this.mentorEditProposal.getMember();
 		}
 		return null;
-	}
-
-	// 멘토 지원서와 연결
-	public void connectToMentorApplyProposal(MentorApplyProposal application) {
-		this.mentorApplyProposal = application;
-	}
-
-	// 멘토 정보 수정 요청과 연결
-	public void connectToMentorModification(MentorEditProposal modification) {
-		this.mentorEditProposal = modification;
 	}
 }

--- a/src/main/java/com/dementor/domain/postattachment/service/PostAttachmentService.java
+++ b/src/main/java/com/dementor/domain/postattachment/service/PostAttachmentService.java
@@ -1,34 +1,5 @@
 package com.dementor.domain.postattachment.service;
 
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.imageio.ImageIO;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-import org.springframework.web.multipart.MultipartFile;
-
 import com.dementor.domain.member.entity.Member;
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
 import com.dementor.domain.mentorapplyproposal.repository.MentorApplyProposalRepository;
@@ -40,9 +11,29 @@ import com.dementor.domain.postattachment.exception.PostAttachmentErrorCode;
 import com.dementor.domain.postattachment.exception.PostAttachmentException;
 import com.dementor.domain.postattachment.repository.PostAttachmentRepository;
 import com.dementor.firebase.service.FirebaseStorageService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -74,12 +65,12 @@ public class PostAttachmentService {
 
 	//멘토 지원서용 파일 업로드 메소드
 	@Transactional
-	public List<FileInfoDto> uploadFilesApply(
+	public void uploadFilesApply(
 		List<MultipartFile> files,
 		MentorApplyProposal applyProposal) {
 
 		if (files == null || files.isEmpty()) {
-			return Collections.emptyList();
+			return;
 		}
 
 		Long memberId = applyProposal.getMember().getId();
@@ -89,8 +80,6 @@ public class PostAttachmentService {
 			throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_LIMIT_EXCEEDED,
 				"파일 업로드 제한을 초과했습니다. 최대 " + maxFilesPerUser + "개까지 가능합니다.");
 		}
-
-		List<FileInfoDto> uploadedFiles = new ArrayList<>();
 
 		for (MultipartFile file : files) {
 			if (file.isEmpty()) {
@@ -117,14 +106,6 @@ public class PostAttachmentService {
 					.build();
 
 				postAttachmentRepository.save(attachment);
-
-				FileInfoDto fileInfo = FileInfoDto.builder()
-					.attachmentId(attachment.getId())
-					.originalFilename(originalFilename)
-					.fileSize(file.getSize())
-					.build();
-
-				uploadedFiles.add(fileInfo);
 			} catch (Exception e) {
 				log.error("파일 업로드 실패: {}", e.getMessage());
 				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_ERROR,
@@ -132,17 +113,16 @@ public class PostAttachmentService {
 			}
 		}
 
-		return uploadedFiles;
 	}
 
 	//멘토 정보 수정용 파일 업로드 메소드
 	@Transactional
-	public List<FileInfoDto> uploadFilesEdit(
+	public void uploadFilesEdit(
 		List<MultipartFile> files,
 		MentorEditProposal editProposal) {
 
 		if (files == null || files.isEmpty()) {
-			return Collections.emptyList();
+			return;
 		}
 
 		Long memberId = editProposal.getMember().getId();
@@ -152,8 +132,6 @@ public class PostAttachmentService {
 			throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_LIMIT_EXCEEDED,
 				"파일 업로드 제한을 초과했습니다. 최대 " + maxFilesPerUser + "개까지 가능합니다.");
 		}
-
-		List<FileInfoDto> uploadedFiles = new ArrayList<>();
 
 		for (MultipartFile file : files) {
 			if (file.isEmpty()) {
@@ -180,14 +158,6 @@ public class PostAttachmentService {
 					.build();
 
 				postAttachmentRepository.save(attachment);
-
-				FileInfoDto fileInfo = FileInfoDto.builder()
-					.attachmentId(attachment.getId())
-					.originalFilename(originalFilename)
-					.fileSize(file.getSize())
-					.build();
-
-				uploadedFiles.add(fileInfo);
 			} catch (Exception e) {
 				log.error("파일 업로드 실패: {}", e.getMessage());
 				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_ERROR,
@@ -195,7 +165,6 @@ public class PostAttachmentService {
 			}
 		}
 
-		return uploadedFiles;
 	}
 
 	//멘토 지원용 마크다운 이미지 처리 메소드

--- a/src/main/java/com/dementor/domain/postattachment/service/PostAttachmentService.java
+++ b/src/main/java/com/dementor/domain/postattachment/service/PostAttachmentService.java
@@ -2,9 +2,7 @@ package com.dementor.domain.postattachment.service;
 
 import com.dementor.domain.member.entity.Member;
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
-import com.dementor.domain.mentorapplyproposal.repository.MentorApplyProposalRepository;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
-import com.dementor.domain.mentoreditproposal.repository.MentorEditProposalRepository;
 import com.dementor.domain.postattachment.dto.response.FileResponse.FileInfoDto;
 import com.dementor.domain.postattachment.entity.PostAttachment;
 import com.dementor.domain.postattachment.exception.PostAttachmentErrorCode;
@@ -42,8 +40,6 @@ public class PostAttachmentService {
 
 	private final PostAttachmentRepository postAttachmentRepository;
 	private final FirebaseStorageService firebaseStorageService;
-	private final MentorApplyProposalRepository mentorApplyProposalRepository;
-	private final MentorEditProposalRepository mentorEditProposalRepository;
 
 	@Value("${file.max-size}")
 	private long maxFileSize;
@@ -167,92 +163,54 @@ public class PostAttachmentService {
 
 	}
 
-	//멘토 지원용 마크다운 이미지 처리 메소드
+	//마크다운용 이미지 파일 업로드 메소드
 	@Transactional
-	public List<FileInfoDto> uploadMarkdownContentForApply(
-		String markdownText,
-		Long applyProposalId) {
-
-		MentorApplyProposal applyProposal = mentorApplyProposalRepository.findById(applyProposalId)
-			.orElseThrow(() -> new PostAttachmentException(
-				PostAttachmentErrorCode.APPLY_PROPOSAL_NOT_FOUND,
-				"멘토 지원서를 찾을 수 없습니다."));
-
-		List<FileInfoDto> uploadedFiles = new ArrayList<>();
-
-		// 마크다운 텍스트 처리 (있는 경우만)
-		if (markdownText != null && !markdownText.isEmpty()) {
-			List<PostAttachment> markdownAttachments = processMarkdownImages(markdownText, applyProposal, null);
-
-			for (PostAttachment attachment : markdownAttachments) {
-				FileInfoDto fileInfo = FileInfoDto.builder()
-					.attachmentId(attachment.getId())
-					.originalFilename(attachment.getOriginalFilename())
-					.fileSize(attachment.getFileSize())
-					.fileUrl("/api/files/markdown-images/" + attachment.getUniqueIdentifier())
-					.uniqueIdentifier(attachment.getUniqueIdentifier())
-					.build();
-
-				uploadedFiles.add(fileInfo);
-			}
+	public List<FileInfoDto> uploadMarkdownImages(List<MultipartFile> images) {
+		if (images == null || images.isEmpty()) {
+			throw new PostAttachmentException(PostAttachmentErrorCode.FILE_REQUIRED);
 		}
 
-		return uploadedFiles;
-	}
-
-	//멘토 수정용 마크다운 이미지 처리 메소드
-	@Transactional
-	public List<FileInfoDto> uploadMarkdownContentForEdit(
-		String markdownText,
-		Long editProposalId) {
-
-		MentorEditProposal editProposal = mentorEditProposalRepository.findById(editProposalId)
-			.orElseThrow(() -> new PostAttachmentException(
-				PostAttachmentErrorCode.EDIT_PROPOSAL_NOT_FOUND,
-				"멘토 정보 수정 요청을 찾을 수 없습니다."));
-
 		List<FileInfoDto> uploadedFiles = new ArrayList<>();
 
-		// 마크다운 텍스트 처리 (있는 경우만)
-		if (markdownText != null && !markdownText.isEmpty()) {
-			List<PostAttachment> markdownAttachments = processMarkdownImages(markdownText, null, editProposal);
-
-			for (PostAttachment attachment : markdownAttachments) {
-				FileInfoDto fileInfo = FileInfoDto.builder()
-					.attachmentId(attachment.getId())
-					.originalFilename(attachment.getOriginalFilename())
-					.fileSize(attachment.getFileSize())
-					.fileUrl("/api/files/markdown-images/" + attachment.getUniqueIdentifier())
-					.uniqueIdentifier(attachment.getUniqueIdentifier())
-					.build();
-
-				uploadedFiles.add(fileInfo);
+		for (MultipartFile image : images) {
+			if (image.isEmpty()) {
+				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_REQUIRED);
 			}
-		}
 
-		return uploadedFiles;
-	}
+			if (image.getSize() > maxFileSize) {
+				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_SIZE_EXCEEDED,
+						"파일 크기가 허용 범위를 초과했습니다. 최대 " + (maxFileSize / (1024 * 1024)) + "MB까지 가능합니다.");
+			}
 
-	@Transactional
-	public List<FileInfoDto> uploadMarkdownContent(String markdownText) {
-		List<FileInfoDto> uploadedFiles = new ArrayList<>();
+			try {
+				String originalFilename = StringUtils.cleanPath(image.getOriginalFilename());
+				String directory = "markdown";
+				String fileUrl = firebaseStorageService.uploadFile(image, directory);
+				String uniqueIdentifier = UUID.randomUUID().toString();
 
-		// 마크다운 텍스트 처리
-		if (markdownText != null && !markdownText.isEmpty()) {
-			// null을 전달하여 특정 proposal에 연결하지 않음
-			List<PostAttachment> markdownAttachments = processMarkdownImages(markdownText, null, null);
+				PostAttachment attachment = PostAttachment.builder()
+						.filename(UUID.randomUUID().toString() + "_" + originalFilename)
+						.originalFilename(originalFilename)
+						.storeFilePath(fileUrl)
+						.fileSize(image.getSize())
+						.uniqueIdentifier(uniqueIdentifier)
+						.build();
 
-			for (PostAttachment attachment : markdownAttachments) {
+				PostAttachment savedAttachment = postAttachmentRepository.save(attachment);
 
-				FileInfoDto fileInfo = FileInfoDto.builder()
-					.attachmentId(attachment.getId())
-					.originalFilename(attachment.getOriginalFilename())
-					.fileSize(attachment.getFileSize())
-					.fileUrl("/api/files/markdown-images/" + attachment.getUniqueIdentifier())
-					.uniqueIdentifier(attachment.getUniqueIdentifier())
-					.build();
+				FileInfoDto fileInfoDto = FileInfoDto.builder()
+						.attachmentId(savedAttachment.getId())
+						.originalFilename(savedAttachment.getOriginalFilename())
+						.fileSize(savedAttachment.getFileSize())
+						.fileUrl("/api/files/markdown-images/" + savedAttachment.getUniqueIdentifier())
+						.uniqueIdentifier(savedAttachment.getUniqueIdentifier())
+						.build();
 
-				uploadedFiles.add(fileInfo);
+				uploadedFiles.add(fileInfoDto);
+			} catch (Exception e) {
+				log.error("파일 업로드 실패: {}", e.getMessage());
+				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_ERROR,
+						"파일 저장 중 오류가 발생했습니다: " + e.getMessage());
 			}
 		}
 
@@ -300,13 +258,6 @@ public class PostAttachmentService {
 					if (!processedAttachments.contains(existingAttachment)) {
 						processedAttachments.add(existingAttachment);
 					}
-				}
-			} else if (imageUrl.startsWith("data:image/")) {
-				try {
-					PostAttachment newImageAttachment = saveBase64Image(imageUrl, altText, applyProposal, editProposal);
-					processedAttachments.add(newImageAttachment);
-				} catch (Exception e) {
-					log.error("Base64 이미지 처리 중 오류 발생: {}", e.getMessage());
 				}
 			} else if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
 				try {
@@ -360,70 +311,6 @@ public class PostAttachmentService {
 		if (lowercaseUrl.contains(".webp"))
 			return ".webp";
 		return ".jpg";
-	}
-
-	private PostAttachment saveBase64Image(
-		String base64Image,
-		String altText,
-		MentorApplyProposal applyProposal,
-		MentorEditProposal editProposal) {
-		try {
-			String[] parts = base64Image.split(",");
-			String imageData = parts.length > 1 ? parts[1] : parts[0];
-
-			String mimeType = "image/jpeg";
-			if (parts.length > 1 && parts[0].contains("image/")) {
-				mimeType = parts[0].substring(parts[0].indexOf("image/"), parts[0].indexOf(";base64"));
-			}
-
-			String extension = ".jpg";
-			if (mimeType.equals("image/png"))
-				extension = ".png";
-			else if (mimeType.equals("image/gif"))
-				extension = ".gif";
-			else if (mimeType.equals("image/svg+xml"))
-				extension = ".svg";
-
-			imageData = imageData.trim().replaceAll("\\s", "");
-
-			byte[] imageBytes;
-			try {
-				imageBytes = Base64.getDecoder().decode(imageData);
-			} catch (IllegalArgumentException e) {
-				throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_ERROR,
-					"올바르지 않은 Base64 인코딩 형식입니다: " + e.getMessage());
-			}
-
-			String originalFilename = (altText.isEmpty() ? "image" : altText) + extension;
-			String directory = "markdown";
-			String fileUrl = firebaseStorageService.uploadFile(
-				imageBytes,
-				originalFilename,
-				mimeType,
-				directory
-			);
-
-			String uniqueIdentifier = UUID.randomUUID().toString();
-			boolean isApplyProposal = (applyProposal != null);
-
-			PostAttachment attachment = PostAttachment.builder()
-				.filename(UUID.randomUUID().toString() + extension)
-				.originalFilename(altText + extension)
-				.storeFilePath(fileUrl)
-				.fileSize((long)imageBytes.length)
-				.mentorApplyProposal(isApplyProposal ? applyProposal : null)
-				.mentorEditProposal(isApplyProposal ? null : editProposal)
-				.uniqueIdentifier(uniqueIdentifier)
-				.build();
-
-			return postAttachmentRepository.save(attachment);
-		} catch (PostAttachmentException e) {
-			throw e;
-		} catch (Exception e) {
-			log.error("Base64 이미지 처리 중 예외 발생: {}", e.getMessage());
-			throw new PostAttachmentException(PostAttachmentErrorCode.FILE_UPLOAD_ERROR,
-				"이미지 처리 중 오류가 발생했습니다: " + e.getMessage());
-		}
 	}
 
 	@Transactional

--- a/src/test/java/com/dementor/mentor/controller/MentorControllerTest.java
+++ b/src/test/java/com/dementor/mentor/controller/MentorControllerTest.java
@@ -141,8 +141,7 @@ public class MentorControllerTest {
 				"testmember@test.com",
 				5,
 				"테스트 회사",
-				"테스트 자기소개",
-				null
+				"테스트 자기소개"
 			);
 
 		// Multipart 본문 중 하나로 보낼 JSON
@@ -183,8 +182,7 @@ public class MentorControllerTest {
 			testJobId,                   // jobId
 			8,                    // career
 			"업데이트 회사",       // currentCompany
-			"업데이트된 자기소개", // introduction
-			null                  // attachmentId
+			"업데이트된 자기소개"  // introduction
 		);
 
 		// JSON 데이터를 multipart로 보내기 위한 MockMultipartFile


### PR DESCRIPTION
## ✨ 변경 사항
- 멘토 지원, 멘토 정보 수정 RequestDto에 attachmentId필드 삭제(멘토 지원, 정보 수정 실행 시 파일 업로드 되기 때문에 attachmentId 생성이 아직 안 되어 있는 상태임)
- 파일 첨부 기존에 Base64 인코딩 방식에서 multipart/form-data방식으로 변경
  - 바이너리 데이터 그대로 전송
  - 서버는 이미지를 저장하고 접근 가능한 URL을 반환

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련된 테스트를 수행했는지 확인 (swagger 확인)
- [x] 리뷰어가 이해하기 쉽도록 설명을 추가했는지 확인

## 🔗 관련 이슈
- 관련 이슈 번호: #136 