### PR TITLE
[Refactor]  채팅방 사용자 기반으로 & 채팅메시지는 기존유지

### DIFF
--- a/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
@@ -37,16 +37,19 @@ public class ChatMessageController {
 	@PostMapping
 	public ResponseEntity<ChatMessageResponseDto> sendMessage(
 		@PathVariable Long chatRoomId,
-		@RequestBody ChatMessageSendDto dto,
-        @AuthenticationPrincipal CustomUserDetails user
+		@RequestBody ChatMessageSendDto dto
+//        @AuthenticationPrincipal CustomUserDetails user
 
     ) {
 
-        Long senderId = user.getId();
-        String authority = user.getAuthorities().iterator().next().getAuthority();
-        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
+		ChatMessageResponseDto response = chatMessageService.sendMessage(chatRoomId, dto);
 
-        ChatMessageResponseDto response = chatMessageService.sendMessage(chatRoomId, dto, senderId, senderType);
+//        Long senderId = user.getId();
+//        String authority = user.getAuthorities().iterator().next().getAuthority();
+//        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
+//
+//        ChatMessageResponseDto response = chatMessageService.sendMessage(chatRoomId, dto, senderId, senderType);
+//
 		return ResponseEntity.ok(response);
 	}
 
@@ -54,14 +57,15 @@ public class ChatMessageController {
 	@MessageMapping("/chat/rooms/{chatRoomId}/messages/create")
 	public void receiveMessageViaWebsocket(
 		@DestinationVariable Long chatRoomId,
-		ChatMessageSendDto dto,
-        @AuthenticationPrincipal CustomUserDetails user // 로그인한 사용자 정보 자동 주입
+		ChatMessageSendDto dto
+//        @AuthenticationPrincipal CustomUserDetails user // 로그인한 사용자 정보 자동 주입
 
 	) {
-        Long senderId = user.getId();
-        String authority = user.getAuthorities().iterator().next().getAuthority();
-        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
+//        Long senderId = user.getId();
+//        String authority = user.getAuthorities().iterator().next().getAuthority();
+//        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
 
-        chatMessageService.sendMessage(chatRoomId,dto, senderId, senderType);
+//        chatMessageService.sendMessage(chatRoomId,dto, senderId, senderType);
+		chatMessageService.sendMessage(chatRoomId, dto);
     }
 }

--- a/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
@@ -41,14 +41,12 @@ public class ChatMessageController {
         @AuthenticationPrincipal CustomUserDetails user
 
     ) {
-		dto.setChatRoomId(chatRoomId);
-        dto.setSenderId(user.getId());
-        // senderType은 Role_ADMIN / ROLE_mentee mentor 에 따라, ADMIN/MEMBER로 분리
+
+        Long senderId = user.getId();
         String authority = user.getAuthorities().iterator().next().getAuthority();
-        dto.setSenderType(authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER);
+        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
 
-
-        ChatMessageResponseDto response = chatMessageService.sendMessage(dto);
+        ChatMessageResponseDto response = chatMessageService.sendMessage(chatRoomId, dto, senderId, senderType);
 		return ResponseEntity.ok(response);
 	}
 
@@ -60,12 +58,10 @@ public class ChatMessageController {
         @AuthenticationPrincipal CustomUserDetails user // 로그인한 사용자 정보 자동 주입
 
 	) {
-        dto.setChatRoomId(chatRoomId); // 채팅방 Id는 경로 변수로 주입
-        dto.setSenderId(user.getId());
-        // senderType은 ROLE 문자열 기준으로 분기
+        Long senderId = user.getId();
         String authority = user.getAuthorities().iterator().next().getAuthority();
-        dto.setSenderType(authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER);
+        SenderType senderType = authority.equals("ROLE_ADMIN") ? SenderType.ADMIN : SenderType.MEMBER;
 
-        chatMessageService.sendMessage(dto);
+        chatMessageService.sendMessage(chatRoomId,dto, senderId, senderType);
     }
 }

--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -35,11 +35,10 @@ public class ChatRoomController {
 	//관리자 챗 채팅방 생성
 	@PostMapping("/admin-room")
 	public ResponseEntity<ChatRoomResponseDto> createAdminChatRoom(
-		@RequestParam Long adminId,
-//		@RequestParam Long
 		@AuthenticationPrincipal CustomUserDetails userDetails
 
-	) {// 로그인된 멤버 Id 가저오기
+	) {
+		// 로그인된 멤버 Id 가저오기
 		Long memberId = userDetails.getId(); // 로그인된 사용자 ID 가져오기
 
 		//멤버 엔티티 조회
@@ -47,7 +46,7 @@ public class ChatRoomController {
 				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
 		//고정 기본 관리자 조회 (예정)
-		Admin admin = adminRepository.findById(adminId)
+		Admin admin = adminRepository.findById(5L)
 			.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
 
 		//채팅방 생성

--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -3,7 +3,7 @@ package com.dementor.domain.chat.controller;
 import com.dementor.domain.admin.entity.Admin;
 import com.dementor.domain.admin.repository.AdminRepository;
 import com.dementor.domain.chat.dto.ChatRoomResponseDto;
-import com.dementor.domain.chat.service.ChatMessageService;
+//import com.dementor.domain.chat.service.ChatMessageService;
 
 import com.dementor.domain.chat.service.ChatRoomService;
 import com.dementor.domain.member.entity.Member;
@@ -25,7 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 public class ChatRoomController {
 
 	private final ChatRoomService chatRoomService;
-	private final ChatMessageService chatMessageService;
+//	private final ChatMessageService chatMessageService;
 
 	private final MemberRepository memberRepository;
 	private final AdminRepository adminRepository;
@@ -72,20 +72,22 @@ public class ChatRoomController {
 	//관리자가 자신의 채팅방목록 조회
 	@GetMapping("/admin/rooms")
 	public ResponseEntity<List<ChatRoomResponseDto>> getMyRoomsAsAdmin(
-		@RequestParam Long adminId
+//		@RequestParam Long adminId
+		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(chatRoomService.getAllMyAdminChatRooms(adminId));
+		return ResponseEntity.ok(chatRoomService.getAllMyAdminChatRooms(userDetails));
 	}
 
 	// ---------------------채팅방 상세 조회--------------------------------------
 	@GetMapping("/room/{chatRoomId}")
 	public ResponseEntity<ChatRoomResponseDto> getChatRoomDetail(
 		@PathVariable Long chatRoomId,
-		@RequestParam Long viewerId,
-		@RequestParam String viewerType
+//		@RequestParam Long viewerId,
+//		@RequestParam String viewerType
+		@AuthenticationPrincipal CustomUserDetails userDetails
+
 	) {
-		ChatRoomResponseDto response = chatRoomService.getChatRoomDetail(chatRoomId, viewerId, viewerType);
-		return ResponseEntity.ok(response);
+		return ResponseEntity.ok(chatRoomService.getChatRoomDetail(chatRoomId, userDetails));
 	}
 
 }

--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -59,10 +59,15 @@ public class ChatRoomController {
 	//멤버가 자신의 채팅방목록 조회
 	@GetMapping("/member/rooms")
 	public ResponseEntity<List<ChatRoomResponseDto>> getMyRoomsAsMember(
-		@RequestParam Long memberId
+//		@RequestParam Long memberId
+			@AuthenticationPrincipal CustomUserDetails userDetails
+
 	) {
+		Long memberId = userDetails.getId();  // 로그인한 사용자 ID 추출
+
 		return ResponseEntity.ok(chatRoomService.getAllMyChatRooms(memberId));
 	}
+
 
 	//관리자가 자신의 채팅방목록 조회
 	@GetMapping("/admin/rooms")

--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -16,6 +16,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import com.dementor.global.security.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat")
@@ -33,14 +36,21 @@ public class ChatRoomController {
 	@PostMapping("/admin-room")
 	public ResponseEntity<ChatRoomResponseDto> createAdminChatRoom(
 		@RequestParam Long adminId,
-		@RequestParam Long memberId
-	) {
+//		@RequestParam Long
+		@AuthenticationPrincipal CustomUserDetails userDetails
+
+	) {// 로그인된 멤버 Id 가저오기
+		Long memberId = userDetails.getId(); // 로그인된 사용자 ID 가져오기
+
+		//멤버 엔티티 조회
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		//고정 기본 관리자 조회 (예정)
 		Admin admin = adminRepository.findById(adminId)
 			.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
 
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
+		//채팅방 생성
 		ChatRoomResponseDto room = chatRoomService.createAdminChatRooms(admin, member); //  반환값 받도록 변경
 
 		return ResponseEntity.ok(room);

--- a/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
+++ b/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
@@ -13,9 +13,10 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ChatMessageSendDto {  // 클라이언트->서버
-
 	//    private MessageType type;  // ENTER / MESSAGE / EXIT
-//	private Long chatRoomId;
+
+	private SenderType senderType;
+	private Long senderId;
 	private String content;    // 메시지 본문
 
 }

--- a/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
+++ b/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
@@ -15,7 +15,7 @@ import lombok.Setter;
 public class ChatMessageSendDto {  // 클라이언트->서버
 
 	//    private MessageType type;  // ENTER / MESSAGE / EXIT
-	private Long chatRoomId;
+//	private Long chatRoomId;
 	private String content;    // 메시지 본문
 
 }

--- a/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
+++ b/src/main/java/com/dementor/domain/chat/dto/ChatMessageSendDto.java
@@ -16,8 +16,6 @@ public class ChatMessageSendDto {  // 클라이언트->서버
 
 	//    private MessageType type;  // ENTER / MESSAGE / EXIT
 	private Long chatRoomId;
-	private SenderType senderType;
-	private Long senderId;
 	private String content;    // 메시지 본문
 
 }

--- a/src/main/java/com/dementor/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dementor/domain/chat/repository/ChatRoomRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
@@ -33,4 +34,17 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 		      AND r.adminId = :adminId
 		""")
 	List<ChatRoom> findAdminChatRoomsByAdminId(@Param("adminId") Long adminId);
+
+
+	// 특정 Admin과 Member 사이의 ADMIN_CHAT 채팅방 조회 (중복 생성 방지용)
+	@Query("""
+    SELECT r FROM ChatRoom r
+    WHERE r.roomType = 'ADMIN_CHAT'
+      AND r.adminId = :adminId
+      AND r.memberId = :memberId
+""")
+	Optional<ChatRoom> findAdminChatRoomByAdminIdAndMemberId(
+			@Param("adminId") Long adminId,
+			@Param("memberId") Long memberId
+	);
 }

--- a/src/main/java/com/dementor/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dementor/domain/chat/repository/ChatRoomRepository.java
@@ -43,7 +43,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       AND r.adminId = :adminId
       AND r.memberId = :memberId
 """)
-	Optional<ChatRoom> findAdminChatRoomByAdminIdAndMemberId(
+	List<ChatRoom> findAdminChatRoomByAdminIdAndMemberId(
 			@Param("adminId") Long adminId,
 			@Param("memberId") Long memberId
 	);

--- a/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
@@ -74,12 +74,6 @@ public class ChatMessageService {
 	@Transactional
 	public ChatMessageResponseDto sendMessage(ChatMessageSendDto dto) {
 
-		// 참여자 검증 로직 추가 (기존 ChatRoomService 로직 재사용)
-		chatRoomService.getChatRoomDetail(
-			dto.getChatRoomId(),
-			dto.getSenderId(),          // senderId == viewerId
-			dto.getSenderType().name().toLowerCase() // senderType == viewerType ( enum → "member"/"admin")
-		);
 
 		// 채팅방 유효성 검사
 		ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())

--- a/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
@@ -73,8 +73,16 @@ public class ChatMessageService {
 	 * - DB에 저장 후, RabbitMQ 통해 실시간 브로드캐스트
 	 */
 	@Transactional
-    public ChatMessageResponseDto sendMessage(Long chatRoomId, ChatMessageSendDto dto, Long senderId, SenderType senderType) {
+//	public ChatMessageResponseDto sendMessage(Long chatRoomId, ChatMessageSendDto dto, Long senderId, SenderType senderType) {
+    public ChatMessageResponseDto sendMessage(Long chatRoomId, ChatMessageSendDto dto) {
 
+//
+//		// 참여자 검증 로직 추가 (기존 ChatRoomService 로직 재사용)
+//		chatRoomService.getChatRoomDetail(
+//				dto.getChatRoomId(),
+//				dto.getSenderId(),          // senderId == viewerId
+//				dto.getSenderType().name().toLowerCase() // senderType == viewerType ( enum → "member"/"admin")
+//		);
 
 		// 채팅방 유효성 검사
 		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
@@ -83,8 +91,8 @@ public class ChatMessageService {
         // 메시지 엔티티 생성
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoom(chatRoom)
-                .senderId(senderId)
-                .senderType(senderType)
+                .senderId(dto.getSenderId())
+                .senderType(dto.getSenderType())
                 .content(dto.getContent())
                 .sentAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
@@ -5,6 +5,7 @@ import com.dementor.domain.chat.dto.ChatMessageSendDto;
 import com.dementor.domain.chat.entity.ChatMessage;
 import com.dementor.domain.chat.entity.ChatRoom;
 import com.dementor.domain.chat.entity.MessageType;
+import com.dementor.domain.chat.entity.SenderType;
 import com.dementor.domain.chat.repository.ChatMessageRepository;
 import com.dementor.domain.chat.repository.ChatRoomRepository;
 
@@ -72,23 +73,23 @@ public class ChatMessageService {
 	 * - DB에 저장 후, RabbitMQ 통해 실시간 브로드캐스트
 	 */
 	@Transactional
-	public ChatMessageResponseDto sendMessage(ChatMessageSendDto dto) {
+    public ChatMessageResponseDto sendMessage(Long chatRoomId, ChatMessageSendDto dto, Long senderId, SenderType senderType) {
 
 
 		// 채팅방 유효성 검사
-		ChatRoom chatRoom = chatRoomRepository.findById(dto.getChatRoomId())
+		ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
 			.orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
 
-		// 메시지 엔티티 생성
-		ChatMessage chatMessage = ChatMessage.builder()
-			.chatRoom(chatRoom)
-			.senderId(dto.getSenderId())
-			.senderType(dto.getSenderType())
-			.content(dto.getContent())
-			.sentAt(LocalDateTime.now())
-			.build();
+        // 메시지 엔티티 생성
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .senderId(senderId)
+                .senderType(senderType)
+                .content(dto.getContent())
+                .sentAt(LocalDateTime.now())
+                .build();
 
-		// DB 저장
+        // DB 저장
 		chatMessageRepository.save(chatMessage);
 		chatRoom.updateLastMessageTime(chatMessage.getSentAt());
 

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -61,14 +61,16 @@ public class ChatRoomService {
 	@Transactional
 	public ChatRoomResponseDto createAdminChatRooms(Admin admin, Member member) {
 
-		// 이미 존재하는 ADMIN_CHAT 채팅방이 있는지 확인
-		Optional<ChatRoom> existingRoom = chatRoomRepository.findAdminChatRoomByAdminIdAndMemberId(
-				admin.getId(), member.getId()
+		// 중복생성 방지
+		Long fixedAdminId = admin.getId(); // 또는 고정된 5L
+
+		List<ChatRoom> existingRooms = chatRoomRepository.findAdminChatRoomByAdminIdAndMemberId(
+				fixedAdminId, member.getId()
 		);
 
-		if (existingRoom.isPresent()) {
-			// 이미 존재한다면 해당 채팅방을 그대로 반환
-			return toDto(existingRoom.get(), admin.getId());
+		if (!existingRooms.isEmpty()) {
+			// 여러 개가 있어도 첫 번째 채팅방만 사용
+			return toDto(existingRooms.get(0), fixedAdminId);
 		}
 
 		//없다면 새로 생성

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
@@ -59,6 +60,18 @@ public class ChatRoomService {
 	// 관리자 채팅방 생성
 	@Transactional
 	public ChatRoomResponseDto createAdminChatRooms(Admin admin, Member member) {
+
+		// 이미 존재하는 ADMIN_CHAT 채팅방이 있는지 확인
+		Optional<ChatRoom> existingRoom = chatRoomRepository.findAdminChatRoomByAdminIdAndMemberId(
+				admin.getId(), member.getId()
+		);
+
+		if (existingRoom.isPresent()) {
+			// 이미 존재한다면 해당 채팅방을 그대로 반환
+			return toDto(existingRoom.get(), admin.getId());
+		}
+
+		//없다면 새로 생성
 		ChatRoom room = ChatRoom.builder()
 			.roomType(RoomType.ADMIN_CHAT)
 			.adminId(admin.getId())

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -8,8 +8,10 @@ import com.dementor.domain.chat.repository.ChatMessageRepository;
 import com.dementor.domain.chat.repository.ChatRoomRepository;
 import com.dementor.domain.admin.entity.Admin;
 import com.dementor.domain.member.entity.Member;
+import com.dementor.domain.member.entity.UserRole;
 import com.dementor.domain.member.repository.MemberRepository;
 
+import com.dementor.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -85,38 +87,49 @@ public class ChatRoomService {
 
 	// 관리자(adminId)기준 참여중인 모든 채팅방 조회
 	@Transactional(readOnly = true)
-	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(Long adminId) {
+//	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(Long adminId) {
+	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(CustomUserDetails userDetails) {
+
+		Long adminId = userDetails.getId();  // 로그인된 관리자 ID
 		List<ChatRoom> rooms = chatRoomRepository.findAdminChatRoomsByAdminId(adminId);
 		return rooms.stream().map(room -> toDto(room, adminId)).toList();
 	}
 
 	//---------------------채팅방 상세 조회(viewerId,viewerType 매칭) --------------------------------------
 	@Transactional(readOnly = true)
-	public ChatRoomResponseDto getChatRoomDetail(Long chatRoomId, Long viewerId, String viewerType) {
+	public ChatRoomResponseDto getChatRoomDetail(Long chatRoomId, CustomUserDetails userDetails) {
 		ChatRoom room = chatRoomRepository.findById(chatRoomId)
-			.orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));  //roomId 존재안함
+				.orElseThrow(() -> new IllegalArgumentException("채팅방이 존재하지 않습니다."));
+
+		Long viewerId = userDetails.getId();
+		String authority = userDetails.getAuthorities().iterator().next().getAuthority(); // ex: ROLE_MENTOR, ROLE_ADMIN
 
 		if (room.getRoomType() == RoomType.MENTORING_CHAT) {
-			// viewerType이 member가 아닐 경우 차단
-			if (!"member" .equals(viewerType)) {
-				throw new SecurityException("멘토링 채팅방은 member만 접근할 수 있습니다.");
+			// getRole()을 직접 호출하지 않고 authority 기반으로 판단
+			if (!"ROLE_MENTOR".equals(authority) && !"ROLE_MENTEE".equals(authority)) {
+				throw new SecurityException("멘토링 채팅방은 멘토 또는 멘티만 접근할 수 있습니다.");
 			}
-			//  viewerId가 mentorId 또는 menteeId와 일치여부
+
 			if (!viewerId.equals(room.getMentorId()) && !viewerId.equals(room.getMenteeId())) {
 				throw new SecurityException("해당 채팅방에 접근할 수 없습니다.");
 			}
 
 		} else if (room.getRoomType() == RoomType.ADMIN_CHAT) {
-			if ("member" .equals(viewerType) && !viewerId.equals(room.getMemberId())) {
-				throw new SecurityException("해당 채팅방에 접근할 수 없습니다.");
-			}
-			if ("admin" .equals(viewerType) && !viewerId.equals(room.getAdminId())) {
-				throw new SecurityException("해당 채팅방에 접근할 수 없습니다.");
+			if ("ROLE_ADMIN".equals(authority)) {
+				if (!viewerId.equals(room.getAdminId())) {
+					throw new SecurityException("해당 채팅방에 접근할 수 없습니다.");
+				}
+			} else {
+				if (!viewerId.equals(room.getMemberId())) {
+					throw new SecurityException("해당 채팅방에 접근할 수 없습니다.");
+				}
 			}
 		}
 
 		return toDto(room, viewerId);
 	}
+
+
 
 	//-----------------------------닉네임관련-----------------------------------
 	// ChatRoomResponseDto 변환 & 실시간 닉네임 조회

--- a/src/main/resources/static/room.html
+++ b/src/main/resources/static/room.html
@@ -19,7 +19,7 @@
 <ul id="chatMessages"></ul>
 
 <script>
-    const chatRoomId = 38; // 테스트할 채팅방 ID
+    const chatRoomId = 52; // 테스트할 채팅방 ID
     const socket = new SockJS("/ws");
     const stompClient = Stomp.over(socket);
 


### PR DESCRIPTION
## ✨ 변경 사항
-채팅방 @AuthenticationPrincipal 사용, 

- 관리자 채팅방 생성시  adminId는 5로 고정
- 관리자 채팅방 중복 생성 방지

-메시지, 연결문제로 senderId, senderType 기존대로 프론트측에서 받기
 

## ✅ 체크리스트
- [* ] 코드가 정상적으로 동작하는지 확인
- [ *] 관련된 테스트를 수행했는지 확인
- [ *] 리뷰어가 이해하기 쉽도록 설명을 추가했는지 확인

