### PR TITLE
[Feat] Feature/be/chat sorting

### DIFF
--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -41,16 +41,16 @@ public class ChatRoomController {
 		// 로그인된 멤버 Id 가저오기
 		Long memberId = userDetails.getId(); // 로그인된 사용자 ID 가져오기
 
-		//멤버 엔티티 조회
-		Member member = memberRepository.findById(memberId)
-				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-		//고정 기본 관리자 조회 (예정)
-		Admin admin = adminRepository.findById(5L)
-			.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
-
+//		//멤버 엔티티 조회
+//		Member member = memberRepository.findById(memberId)
+//				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+//
+//		//고정 기본 관리자 조회
+//		Admin admin = adminRepository.findById(5L)
+//			.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
+//
 		//채팅방 생성
-		ChatRoomResponseDto room = chatRoomService.createAdminChatRooms(admin, member); //  반환값 받도록 변경
+		ChatRoomResponseDto room = chatRoomService.createAdminChatRooms(memberId); //  반환값 받도록 변경
 
 		return ResponseEntity.ok(room);
 	}
@@ -58,7 +58,6 @@ public class ChatRoomController {
 	//멤버가 자신의 채팅방목록 조회
 	@GetMapping("/member/rooms")
 	public ResponseEntity<List<ChatRoomResponseDto>> getMyRoomsAsMember(
-//		@RequestParam Long memberId
 			@AuthenticationPrincipal CustomUserDetails userDetails
 
 	) {
@@ -71,7 +70,6 @@ public class ChatRoomController {
 	//관리자가 자신의 채팅방목록 조회
 	@GetMapping("/admin/rooms")
 	public ResponseEntity<List<ChatRoomResponseDto>> getMyRoomsAsAdmin(
-//		@RequestParam Long adminId
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
 		return ResponseEntity.ok(chatRoomService.getAllMyAdminChatRooms(userDetails));
@@ -81,8 +79,6 @@ public class ChatRoomController {
 	@GetMapping("/room/{chatRoomId}")
 	public ResponseEntity<ChatRoomResponseDto> getChatRoomDetail(
 		@PathVariable Long chatRoomId,
-//		@RequestParam Long viewerId,
-//		@RequestParam String viewerType
 		@AuthenticationPrincipal CustomUserDetails userDetails
 
 	) {

--- a/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatRoomController.java
@@ -31,29 +31,20 @@ public class ChatRoomController {
 	private final AdminRepository adminRepository;
 
 	// 멘토링 채팅방은 별도 api 필요없음( ApplyService.createApply() 내부에서 채팅방이 자동으로 생성)
-	//ApplyService에서 apply 저장 후, mentor, mentee를 DB에서 꺼내서 chatRoomService.createMentoringChatRooms(...) 로 2번 저장까지 완료
+
 	//관리자 챗 채팅방 생성
 	@PostMapping("/admin-room")
 	public ResponseEntity<ChatRoomResponseDto> createAdminChatRoom(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 
 	) {
-		// 로그인된 멤버 Id 가저오기
 		Long memberId = userDetails.getId(); // 로그인된 사용자 ID 가져오기
 
-//		//멤버 엔티티 조회
-//		Member member = memberRepository.findById(memberId)
-//				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-//
-//		//고정 기본 관리자 조회
-//		Admin admin = adminRepository.findById(5L)
-//			.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
-//
 		//채팅방 생성
 		ChatRoomResponseDto room = chatRoomService.createAdminChatRooms(memberId); //  반환값 받도록 변경
-
 		return ResponseEntity.ok(room);
 	}
+
 
 	//멤버가 자신의 채팅방목록 조회
 	@GetMapping("/member/rooms")
@@ -61,6 +52,10 @@ public class ChatRoomController {
 			@AuthenticationPrincipal CustomUserDetails userDetails
 
 	) {
+		String authority = userDetails.getAuthorities().iterator().next().getAuthority();
+		if ("ROLE_ADMIN".equals(authority)) {
+			throw new SecurityException("관리자는 접근할 수 없습니다.");
+		}
 		Long memberId = userDetails.getId();  // 로그인한 사용자 ID 추출
 
 		return ResponseEntity.ok(chatRoomService.getAllMyChatRooms(memberId));
@@ -72,10 +67,16 @@ public class ChatRoomController {
 	public ResponseEntity<List<ChatRoomResponseDto>> getMyRoomsAsAdmin(
 		@AuthenticationPrincipal CustomUserDetails userDetails
 	) {
-		return ResponseEntity.ok(chatRoomService.getAllMyAdminChatRooms(userDetails));
+		String authority = userDetails.getAuthorities().iterator().next().getAuthority();
+		if (!"ROLE_ADMIN".equals(authority)) {
+			throw new SecurityException("관리자만 접근할 수 있습니다.");
+		}
+		Long adminId = userDetails.getId();
+		return ResponseEntity.ok(chatRoomService.getAllMyAdminChatRooms(adminId));
 	}
 
-	// ---------------------채팅방 상세 조회--------------------------------------
+
+	// 채팅방 상세조회
 	@GetMapping("/room/{chatRoomId}")
 	public ResponseEntity<ChatRoomResponseDto> getChatRoomDetail(
 		@PathVariable Long chatRoomId,

--- a/src/main/java/com/dementor/domain/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/dementor/domain/chat/dto/ChatRoomResponseDto.java
@@ -20,4 +20,5 @@ public class ChatRoomResponseDto {
 	private String lastMessage;  // 마지막 메시지 내용
 	private ZonedDateTime lastMessageAt; // 마지막 메시지 보낸시간
 	private String targetNickname;  //상대방 닉네임
+	private Long targetId; //상대방 ID
 }

--- a/src/main/java/com/dementor/domain/chat/entity/ViewerType.java
+++ b/src/main/java/com/dementor/domain/chat/entity/ViewerType.java
@@ -1,0 +1,6 @@
+package com.dementor.domain.chat.entity;
+
+public enum ViewerType {
+    ADMIN,
+    MEMBER
+}

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -108,14 +108,8 @@ public class ChatRoomService {
 
 	// 관리자(adminId)기준 참여중인 모든 채팅방 조회
 	@Transactional(readOnly = true)
-	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(CustomUserDetails userDetails) {
+	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(Long adminId) {
 
-		String authority = userDetails.getAuthorities().iterator().next().getAuthority();
-		if (!"ROLE_ADMIN".equals(authority)) {
-			throw new SecurityException("관리자만 접근할 수 있습니다.");
-		}
-
-		Long adminId = userDetails.getId();  // 로그인된 관리자 ID
 		List<ChatRoom> rooms = chatRoomRepository.findAdminChatRoomsByAdminId(adminId);
 		return rooms.stream().map(room -> toDto(room, adminId, ViewerType.ADMIN)).toList();
 	}

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -1,9 +1,11 @@
 package com.dementor.domain.chat.service;
 
+import com.dementor.domain.admin.repository.AdminRepository;
 import com.dementor.domain.chat.dto.ChatRoomResponseDto;
 import com.dementor.domain.chat.entity.ChatMessage;
 import com.dementor.domain.chat.entity.ChatRoom;
 import com.dementor.domain.chat.entity.RoomType;
+import com.dementor.domain.chat.entity.ViewerType;
 import com.dementor.domain.chat.repository.ChatMessageRepository;
 import com.dementor.domain.chat.repository.ChatRoomRepository;
 import com.dementor.domain.admin.entity.Admin;
@@ -30,6 +32,8 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final ChatMessageRepository chatMessageRepository;
 	private final MemberRepository memberRepository;
+	private final AdminRepository adminRepository;
+
 
 	//닉네임 캐시 저장 - (닉네임캐싱) 최초 1회만 DB 조회 후 메모리 캐시에서 꺼냄
 	private final Map<Long, String> nicknameCache = new ConcurrentHashMap<>();
@@ -48,43 +52,47 @@ public class ChatRoomService {
 
 		// 새로운 채팅방 생성
 		ChatRoom newRoom = ChatRoom.builder()
-			.roomType(RoomType.MENTORING_CHAT)
-			.mentorId(mentorId)
-			.menteeId(menteeId)
-			//                .targetNickname(mentorNickname) // 기본값 (멘티 기준)
-			.build();
+				.roomType(RoomType.MENTORING_CHAT)
+				.mentorId(mentorId)
+				.menteeId(menteeId)
+				//                .targetNickname(mentorNickname) // 기본값 (멘티 기준)
+				.build();
 
 		return chatRoomRepository.save(newRoom);
 	}
 
 	// 관리자 채팅방 생성
 	@Transactional
-	public ChatRoomResponseDto createAdminChatRooms(Admin admin, Member member) {
+//	public ChatRoomResponseDto createAdminChatRooms(Admin admin, Member member) {
+	public ChatRoomResponseDto createAdminChatRooms(Long memberId) {
 
-		// 중복생성 방지
-		Long fixedAdminId = admin.getId(); // 또는 고정된 5L
 
+		// 멤버 조회
+		Member member = memberRepository.findById(memberId)
+				.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+		// DB에서 고정 관리자 조회 (ID = 5L)
+		Admin admin = adminRepository.findById(5L)
+				.orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다."));
+
+
+		Long fixedAdminId = admin.getId();
+
+		// 기존 방 존재 여부 확인
 		List<ChatRoom> existingRooms = chatRoomRepository.findAdminChatRoomByAdminIdAndMemberId(
 				fixedAdminId, member.getId()
 		);
-
 		if (!existingRooms.isEmpty()) {
-			// 여러 개가 있어도 첫 번째 채팅방만 사용
-			return toDto(existingRooms.get(0), fixedAdminId);
+			return toDto(existingRooms.get(0), member.getId(), ViewerType.MEMBER); // 수정: viewerType 추가
 		}
-
-		//없다면 새로 생성
+		// 새 채팅방 생성
 		ChatRoom room = ChatRoom.builder()
-			.roomType(RoomType.ADMIN_CHAT)
-			.adminId(admin.getId())
-			.memberId(member.getId())
-			//                .targetNickname("관리자") // 하드코딩된 관리자 닉네임
-			.build();
-
+				.roomType(RoomType.ADMIN_CHAT)
+				.adminId(admin.getId())
+				.memberId(member.getId())
+				.build();
 		chatRoomRepository.save(room);
-
-		return toDto(room, member.getId());  //dto 매개변수 viewerid
-
+		return toDto(room, member.getId(), ViewerType.MEMBER); // 수정: viewerType 추가
 	}
 	//--------------------------채팅방 목록 조회--------------------------------------
 
@@ -95,9 +103,9 @@ public class ChatRoomService {
 		List<ChatRoom> adminRooms = chatRoomRepository.findAdminChatRoomsByMemberId(memberId);
 
 		return List.of(mentoringRooms, adminRooms).stream()
-			.flatMap(List::stream)
-			.map(room -> toDto(room, memberId)) // viewerId 넘기기
-			.toList();
+				.flatMap(List::stream)
+				.map(room -> toDto(room, memberId, ViewerType.MEMBER )) // viewerId 넘기기
+				.toList();
 	}
 
 	// 관리자(adminId)기준 참여중인 모든 채팅방 조회
@@ -105,9 +113,15 @@ public class ChatRoomService {
 //	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(Long adminId) {
 	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(CustomUserDetails userDetails) {
 
+		String authority = userDetails.getAuthorities().iterator().next().getAuthority();
+
+		if (!"ROLE_ADMIN".equals(authority)) {
+			throw new SecurityException("관리자만 접근할 수 있습니다.");
+		}
+
 		Long adminId = userDetails.getId();  // 로그인된 관리자 ID
 		List<ChatRoom> rooms = chatRoomRepository.findAdminChatRoomsByAdminId(adminId);
-		return rooms.stream().map(room -> toDto(room, adminId)).toList();
+		return rooms.stream().map(room -> toDto(room, adminId, ViewerType.ADMIN)).toList();
 	}
 
 	//---------------------채팅방 상세 조회(viewerId,viewerType 매칭) --------------------------------------
@@ -118,6 +132,7 @@ public class ChatRoomService {
 
 		Long viewerId = userDetails.getId();
 		String authority = userDetails.getAuthorities().iterator().next().getAuthority(); // ex: ROLE_MENTOR, ROLE_ADMIN
+		ViewerType viewerType = "ROLE_ADMIN".equals(authority) ? ViewerType.ADMIN : ViewerType.MEMBER;
 
 		if (room.getRoomType() == RoomType.MENTORING_CHAT) {
 			// getRole()을 직접 호출하지 않고 authority 기반으로 판단
@@ -141,55 +156,62 @@ public class ChatRoomService {
 			}
 		}
 
-		return toDto(room, viewerId);
+		return toDto(room, viewerId, viewerType);
 	}
-
 
 
 	//-----------------------------닉네임관련-----------------------------------
 	// ChatRoomResponseDto 변환 & 실시간 닉네임 조회
-	private ChatRoomResponseDto toDto(ChatRoom room, Long viewerId) {
+	private ChatRoomResponseDto toDto(ChatRoom room, Long viewerId, ViewerType viewerType) {
 		List<ChatMessage> messages = chatMessageRepository
-			.findTop1ByChatRoom_ChatRoomIdOrderBySentAtDesc(room.getChatRoomId());
+				.findTop1ByChatRoom_ChatRoomIdOrderBySentAtDesc(room.getChatRoomId());
 		ChatMessage lastMessage = messages.isEmpty() ? null : messages.get(0);
 
-		String targetNickname = getTargetNickname(room, viewerId);
+		String targetNickname = getTargetNickname(room, viewerId, viewerType);
 
 		return new ChatRoomResponseDto(
-			room.getChatRoomId(),
-			room.getRoomType(),
-			lastMessage != null ? lastMessage.getContent() : null,
-			lastMessage != null ? lastMessage.getSentAt().atZone(ZoneId.of("Asia/Seoul")) : null,
-			targetNickname
+				room.getChatRoomId(),
+				room.getRoomType(),
+				lastMessage != null ? lastMessage.getContent() : null,
+				lastMessage != null ? lastMessage.getSentAt().atZone(ZoneId.of("Asia/Seoul")) : null,
+				targetNickname
 		);
 	}
 
 	// 자신의 입장에서 상대방 닉네임 반환 (캐시를 이용해서 닉네임 조회)
-	public String getTargetNickname(ChatRoom room, Long viewerId) {
-		if (room.getRoomType() == RoomType.MENTORING_CHAT) {
+	public String getTargetNickname(ChatRoom room, Long viewerId, ViewerType viewerType) {
+		if (room.getRoomType() == RoomType.MENTORING_CHAT) {  //viewerType이 member라는 가정
 			Long targetId = viewerId.equals(room.getMentorId())
-				? room.getMenteeId()
-				: room.getMentorId();
+					? room.getMenteeId()
+					: room.getMentorId();
 
 			// 캐시 적용: 처음만 DB에서 조회, 이후 캐시에서 가져옴
 			return nicknameCache.computeIfAbsent(targetId, id ->
-				memberRepository.findById(id)
-					.map(Member::getNickname)
-					.orElse("알 수 없음")
+					memberRepository.findById(id)
+							.map(Member::getNickname)
+							.orElse("알 수 없음")
 			);
 		}
 
 		// 관리자 채팅: viewer가 관리자면 → 상대 member 닉네임 조회
 		if (room.getRoomType() == RoomType.ADMIN_CHAT) {
-			if (viewerId.equals(room.getAdminId())) {
-				return memberRepository.findById(room.getMemberId())
-					.map(Member::getNickname)
-					.orElse("알 수 없음");
-			} else {
-				return "관리자"; // 사용자 입장에서 → '관리자'
+			if (viewerType == ViewerType.ADMIN) {
+				if (viewerId.equals(room.getAdminId())) {
+
+					return memberRepository.findById(room.getMemberId())
+							.map(Member::getNickname)
+							.orElse("알 수 없음");
+				}
+			} else if (viewerType == ViewerType.MEMBER) {
+				if (viewerId.equals(room.getMemberId())) {
+					// viewer가 이 방의 멤버일 경우 → 상대는 관리자
+					return "관리자";
+				}
 			}
 		}
 
 		return "알 수 없음";
 	}
 }
+
+

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -83,7 +83,7 @@ public class ChatRoomService {
 
 		chatRoomRepository.save(room);
 
-		return toDto(room, admin.getId());  //dto 매개변수 viewerid
+		return toDto(room, member.getId());  //dto 매개변수 viewerid
 
 	}
 	//--------------------------채팅방 목록 조회--------------------------------------


### PR DESCRIPTION
메시쪽에서 프론트로 부터 senderId, senderType을 받기때문에 
send메시지에서  참여자 검증로직 있어야함.

리팩토링시 메서드 따로 빼서  채팅방 상세조회, sendmessage에서 공통으로 사용되게 (현재는 룸서비스에서 userDtails 사용중이라, 해당 로직 그대로 사용 불가)
