### PR TITLE
[REFACTOR] 멘토 지원, 멘토 정보 수정 요청 조회에 직무, 파일 필드 추가

### DIFF
--- a/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/dementor/domain/chat/controller/ChatMessageController.java
@@ -33,7 +33,7 @@ public class ChatMessageController {
 		return ResponseEntity.ok(messages);
 	}
 
-	// 2. 메시지 전송 (REST) 클->서버, 메시지 저장
+	// 2. 메시지 전송 (REST) swagger 또는 테스트용
 	@PostMapping
 	public ResponseEntity<ChatMessageResponseDto> sendMessage(
 		@PathVariable Long chatRoomId,
@@ -53,7 +53,7 @@ public class ChatMessageController {
 		return ResponseEntity.ok(response);
 	}
 
-	// 3. 메시지 전송 (WebSocket), RabbitMQ 통해 서버->클(구독자)
+	// 3. 메시지 전송 (WebSocket), RabbitMQ 통해 클->서버->브로커->클
 	@MessageMapping("/chat/rooms/{chatRoomId}/messages/create")
 	public void receiveMessageViaWebsocket(
 		@DestinationVariable Long chatRoomId,

--- a/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatMessageService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
@@ -54,7 +55,7 @@ public class ChatMessageService {
 
 		// 오래된 순으로 정렬
 		return messages.stream()
-			.sorted((m1, m2) -> Long.compare(m1.getChatMessageId(), m2.getChatMessageId()))
+			.sorted(Comparator.comparingLong(ChatMessage::getChatMessageId))
 			.map(chatMessage -> new ChatMessageResponseDto(
 				chatMessage.getChatRoom().getChatRoomId(),
 				chatMessage.getSenderId(),

--- a/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/dementor/domain/chat/service/ChatRoomService.java
@@ -103,6 +103,11 @@ public class ChatRoomService {
 		return List.of(mentoringRooms, adminRooms).stream()
 				.flatMap(List::stream)
 				.map(room -> toDto(room, memberId, ViewerType.MEMBER )) // viewerId 넘기기
+				.sorted((r1, r2) -> { // 최근 메시지 기준 정렬 추가
+					if (r1.getLastMessageAt() == null) return 1;
+					if (r2.getLastMessageAt() == null) return -1;
+					return r2.getLastMessageAt().compareTo(r1.getLastMessageAt());
+				})
 				.toList();
 	}
 
@@ -111,7 +116,14 @@ public class ChatRoomService {
 	public List<ChatRoomResponseDto> getAllMyAdminChatRooms(Long adminId) {
 
 		List<ChatRoom> rooms = chatRoomRepository.findAdminChatRoomsByAdminId(adminId);
-		return rooms.stream().map(room -> toDto(room, adminId, ViewerType.ADMIN)).toList();
+		return rooms.stream()
+				.map(room -> toDto(room, adminId, ViewerType.ADMIN))
+				.sorted((r1, r2) -> { // 최근 메시지 기준 정렬 추가
+					if (r1.getLastMessageAt() == null) return 1;
+					if (r2.getLastMessageAt() == null) return -1;
+					return r2.getLastMessageAt().compareTo(r1.getLastMessageAt());
+				})
+				.toList();
 	}
 
 

--- a/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
+++ b/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
@@ -160,7 +160,7 @@ public class MentorController {
 	}
 
 	@GetMapping("/{memberId}/modification-requests")
-	@PreAuthorize("hasRole('MENTOR') and #memberId == authentication.principal.id or hasRole('ADMIN')")
+	@PreAuthorize("(hasRole('MENTOR') and #memberId == authentication.principal.id) or hasRole('ADMIN')")
 	// 본인 멘토 또는 관리자만 조회 가능
 	@Operation(summary = "멘토 정보 수정 요청 조회", description = "특정 멘토의 정보 수정 요청 이력과 상태를 조회합니다. - 로그인한 멘토만 가능")
 	public ResponseEntity<ApiResponse<?>> getModificationRequests(
@@ -175,12 +175,6 @@ public class MentorController {
 			if (!exists) {
 				return ResponseEntity.status(HttpStatus.NOT_FOUND)
 					.body(ApiResponse.of(false, HttpStatus.NOT_FOUND, "해당 멘토를 찾을 수 없습니다: " + memberId));
-			}
-
-			// 권한 체크: 로그인한 사용자와 요청된 멘토 ID가 일치하는지
-			if (!memberId.equals(userDetails.getId())) {
-				return ResponseEntity.status(HttpStatus.FORBIDDEN)
-					.body(ApiResponse.of(false, HttpStatus.FORBIDDEN, "해당 멘토 정보 수정 요청을 조회할 권한이 없습니다."));
 			}
 
 			// 페이지 번호와 크기 유효성 검사

--- a/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
+++ b/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
@@ -39,7 +39,7 @@ public class MentorChangeResponse {
 	) {
 	}
 
-	public record AttachmentInfo(Long id, String originalFilename, String downloadUrl) {
+	public record AttachmentInfo(Long attachmentId, String fileName, String fileUrl) {
 		public static AttachmentInfo from(PostAttachment attachment) {
 			return new AttachmentInfo(
 					attachment.getId(),

--- a/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
+++ b/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
@@ -1,5 +1,7 @@
 package com.dementor.domain.mentor.dto.response;
 
+import com.dementor.domain.postattachment.entity.PostAttachment;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -14,10 +16,11 @@ public class MentorChangeResponse {
 
 	// 수정 요청 데이터 개별 항목 DTO
 	public record ChangeRequestData(
-		Long requestId,
+		Long proposalId,
 		String status,
-		LocalDateTime requestDate,
-		Map<String, FieldChange<?>> modifiedFields
+		LocalDateTime createdAt,
+		Map<String, FieldChange<?>> modifiedFields,
+		List<AttachmentInfo> attachments
 	) {
 	}
 
@@ -27,9 +30,6 @@ public class MentorChangeResponse {
 		Integer size,
 		Long totalElements
 	) {
-		public Long getTotalPages() {
-			return (totalElements + size - 1) / size;
-		}
 	}
 
 	// 응답 데이터 DTO
@@ -37,5 +37,15 @@ public class MentorChangeResponse {
 		List<ChangeRequestData> modificationRequests,
 		Pagination pagination
 	) {
+	}
+
+	public record AttachmentInfo(Long id, String originalFilename, String downloadUrl) {
+		public static AttachmentInfo from(PostAttachment attachment) {
+			return new AttachmentInfo(
+					attachment.getId(),
+					attachment.getOriginalFilename(),
+					"/api/files/" + attachment.getId() + "/download"
+			);
+		}
 	}
 }

--- a/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
+++ b/src/main/java/com/dementor/domain/mentor/dto/response/MentorChangeResponse.java
@@ -43,7 +43,7 @@ public class MentorChangeResponse {
 		public static AttachmentInfo from(PostAttachment attachment) {
 			return new AttachmentInfo(
 					attachment.getId(),
-					attachment.getOriginalFilename(),
+					attachment.getFilename(),
 					"/api/files/" + attachment.getId() + "/download"
 			);
 		}

--- a/src/main/java/com/dementor/domain/mentor/service/MentorService.java
+++ b/src/main/java/com/dementor/domain/mentor/service/MentorService.java
@@ -97,7 +97,7 @@ public class MentorService {
 		}
 
 		// 응답 데이터 구성
-		return ApplymentResponse.from(savedProposal, savedProposal.getJob());
+		return ApplymentResponse.from(savedProposal);
 	}
 
 	//멘토 정보 업데이트
@@ -141,8 +141,7 @@ public class MentorService {
 		}
 
 		// 응답 데이터 구성
-		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(savedModification.getId());
-		return MentorEditUpdateRenewalResponse.from(savedModification, attachments);
+		return MentorEditUpdateRenewalResponse.from(savedModification);
 	}
 
 	// 멘토 지원서 생성 및 저장을 위한 내부 메소드

--- a/src/main/java/com/dementor/domain/mentor/service/MentorService.java
+++ b/src/main/java/com/dementor/domain/mentor/service/MentorService.java
@@ -29,6 +29,7 @@ import com.dementor.domain.mentoreditproposal.dto.MentorEditUpdateRenewalRespons
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
 import com.dementor.domain.mentoreditproposal.repository.MentorEditProposalRepository;
+import com.dementor.domain.postattachment.entity.PostAttachment;
 import com.dementor.domain.postattachment.repository.PostAttachmentRepository;
 import com.dementor.domain.postattachment.service.PostAttachmentService;
 import jakarta.transaction.Transactional;
@@ -57,6 +58,7 @@ public class MentorService {
 	private final MentorApplyProposalRepository mentorApplyProposalRepository;
 	private final ApplyRepository applyRepository;
 	private final PostAttachmentService postAttachmentService;
+	private final PostAttachmentRepository postAttachmentRepository;
 
 	//멘토 지원하기
 	@Transactional
@@ -139,7 +141,8 @@ public class MentorService {
 		}
 
 		// 응답 데이터 구성
-		return MentorEditUpdateRenewalResponse.from(savedModification);
+		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(savedModification.getId());
+		return MentorEditUpdateRenewalResponse.from(savedModification, attachments);
 	}
 
 	// 멘토 지원서 생성 및 저장을 위한 내부 메소드
@@ -275,11 +278,17 @@ public class MentorService {
 				new MentorChangeResponse.FieldChange<>(mentor.getIntroduction(), proposal.getIntroduction()));
 		}
 
+		List<PostAttachment> postAttachments = postAttachmentRepository.findByMentorEditProposalId(proposal.getId());
+		List<MentorChangeResponse.AttachmentInfo> attachments = postAttachments.stream()
+				.map(MentorChangeResponse.AttachmentInfo::from)
+				.collect(Collectors.toList());
+
 		return new MentorChangeResponse.ChangeRequestData(
 			proposal.getId(),
 			proposal.getStatus().name(),
 			proposal.getCreatedAt(),
-			modifiedFields
+			modifiedFields,
+			attachments
 		);
 	}
 

--- a/src/main/java/com/dementor/domain/mentor/service/MentorService.java
+++ b/src/main/java/com/dementor/domain/mentor/service/MentorService.java
@@ -42,9 +42,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -53,7 +51,6 @@ public class MentorService {
 	private final MentorRepository mentorRepository;
 	private final MemberRepository memberRepository;
 	private final JobRepository jobRepository;
-	private final PostAttachmentRepository attachmentRepository;
 	private final MentorEditProposalRepository mentorEditProposalRepository;
 	private final MentorApplyProposalRepository mentorApplyProposalRepository;
 	private final ApplyRepository applyRepository;
@@ -117,16 +114,23 @@ public class MentorService {
 				"이미 정보 수정 요청 중입니다: " + memberId);
 		}
 
-		// 변경 사항이 있는지 확인
-		if (!requestDto.hasChanges(mentor)) {
+		// 기본 데이터 변경 여부 확인
+		boolean dataChanged = requestDto.hasChanges(mentor);
+
+		// 파일 변경 여부는 파일이 존재하는지만 확인 (단순화)
+		boolean filesChanged = (files != null && !files.isEmpty());
+
+		if (!dataChanged && !filesChanged) {
 			throw new MentorException(MentorErrorCode.INVALID_MENTOR_APPLICATION,
-				"변경된 내용이 없습니다.");
+					"변경된 내용이 없습니다.");
 		}
 
 		// 직무 엔티티 조회
-		Job job = jobRepository.findById(requestDto.getJobId())
+		Job job = (requestDto.getJobId() != null)
+				? jobRepository.findById(requestDto.getJobId())
 				.orElseThrow(() -> new MentorException(MentorErrorCode.JOB_NOT_FOUND,
-						"직무 정보를 찾을 수 없습니다: " + requestDto.getJobId()));
+						"직무 정보를 찾을 수 없습니다: " + requestDto.getJobId()))
+				: mentor.getJob();
 
 		// 수정 요청 엔티티 생성 및 저장
 		MentorEditProposal savedModification = createAndSaveMentorModification(requestDto, mentor, job);
@@ -136,7 +140,7 @@ public class MentorService {
 		mentorRepository.save(mentor);
 
 		// 파일 업로드 처리
-		if (files != null && !files.isEmpty()) {
+		if (filesChanged) {
 			postAttachmentService.uploadFilesEdit(files, savedModification);
 		}
 
@@ -173,10 +177,12 @@ public class MentorService {
 
 		MentorEditProposal modification = MentorEditProposal.builder()
 				.member(mentor.getMember())
-				.career(requestDto.getCareer())
-				.currentCompany(requestDto.getCurrentCompany())
+				.career(requestDto.getCareer() != null ? requestDto.getCareer() : mentor.getCareer())
+				.currentCompany(requestDto.getCurrentCompany() != null ?
+						requestDto.getCurrentCompany() : mentor.getCurrentCompany())
 				.job(job)
-				.introduction(requestDto.getIntroduction())
+				.introduction(requestDto.getIntroduction() != null ?
+						requestDto.getIntroduction() : mentor.getIntroduction())
 				.status(MentorEditProposalStatus.PENDING)
 				.build();
 

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentDetailResponse.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentDetailResponse.java
@@ -1,17 +1,19 @@
 package com.dementor.domain.mentorapplyproposal.dto.response;
 
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
+import com.dementor.domain.postattachment.entity.PostAttachment;
+
+import java.util.List;
 
 public record ApplymentDetailResponse(
 	ApplymentInfo applymentInfo
 ) {
 	public static ApplymentDetailResponse from(
-		MentorApplyProposal applyment
-		//            Job job
-		//            List<PostAttachment> attachments
+		MentorApplyProposal applyment,
+		List<PostAttachment> attachments
 	) {
 		return new ApplymentDetailResponse(
-			ApplymentInfo.from(applyment)
+			ApplymentInfo.from(applyment, attachments)
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentInfo.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentInfo.java
@@ -1,6 +1,9 @@
 package com.dementor.domain.mentorapplyproposal.dto.response;
 
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
+import com.dementor.domain.postattachment.entity.PostAttachment;
+
+import java.util.List;
 
 public record ApplymentInfo(
 	Long applymentId,
@@ -14,13 +17,12 @@ public record ApplymentInfo(
 	String introduction,
 	String status,
 	String createdAt,
-	String modifiedAt
-	//        List<AttachmentInfo> attachments
+	String modifiedAt,
+	List<AttachmentInfo> attachments
 ) {
 	public static ApplymentInfo from(
-		MentorApplyProposal applyment
-		//            Job job
-		//            List<PostAttachment> attachments
+		MentorApplyProposal applyment,
+		List<PostAttachment> attachments
 	) {
 		return new ApplymentInfo(
 			applyment.getId(),
@@ -34,10 +36,10 @@ public record ApplymentInfo(
 			applyment.getIntroduction(),
 			applyment.getStatus().name(),
 			applyment.getCreatedAt().toString(),
-			applyment.getModifiedAt() != null ? applyment.getModifiedAt().toString() : null
-			//                attachments.stream()
-			//                        .map(AttachmentInfo::from)
-			//                        .toList()
+			applyment.getModifiedAt() != null ? applyment.getModifiedAt().toString() : null,
+			attachments.stream()
+					.map(AttachmentInfo::from)
+					.toList()
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentResponse.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/ApplymentResponse.java
@@ -1,6 +1,5 @@
 package com.dementor.domain.mentorapplyproposal.dto.response;
 
-import com.dementor.domain.job.entity.Job;
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
 
 public record ApplymentResponse(
@@ -13,13 +12,13 @@ public record ApplymentResponse(
 	String status,
 	String createdAt
 ) {
-	public static ApplymentResponse from(MentorApplyProposal applyment, Job job) {
+	public static ApplymentResponse from(MentorApplyProposal applyment) {
 		return new ApplymentResponse(
 			applyment.getId(),
 			applyment.getMember().getId(),
 			applyment.getName(),
 			applyment.getEmail(),
-			job.getName(),
+			applyment.getJob().getName(),
 			applyment.getCareer(),
 			applyment.getStatus().name(),
 			applyment.getCreatedAt().toString()

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/AttachmentInfo.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/dto/response/AttachmentInfo.java
@@ -9,9 +9,9 @@ public record AttachmentInfo(
 ) {
 	public static AttachmentInfo from(PostAttachment attachment) {
 		return new AttachmentInfo(
-			attachment.getId(),
-			attachment.getFilename(),
-			attachment.getStoreFilePath()
+				attachment.getId(),
+				attachment.getFilename(),
+				"/api/files/" + attachment.getId() + "/download"
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/service/AdminMentorApplymentService.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/service/AdminMentorApplymentService.java
@@ -1,14 +1,5 @@
 package com.dementor.domain.mentorapplyproposal.service;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-
-import com.dementor.domain.mentorapplyproposal.dto.request.ApplymentRejectRequest;
-import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentApprovalResponse;
-import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentDetailResponse;
-import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentRejectResponse;
-import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentResponse;
 import com.dementor.domain.job.entity.Job;
 import com.dementor.domain.job.repository.JobRepository;
 import com.dementor.domain.member.entity.Member;
@@ -16,12 +7,23 @@ import com.dementor.domain.member.entity.UserRole;
 import com.dementor.domain.member.repository.MemberRepository;
 import com.dementor.domain.mentor.entity.Mentor;
 import com.dementor.domain.mentor.repository.MentorRepository;
+import com.dementor.domain.mentorapplyproposal.dto.request.ApplymentRejectRequest;
+import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentApprovalResponse;
+import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentDetailResponse;
+import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentRejectResponse;
+import com.dementor.domain.mentorapplyproposal.dto.response.ApplymentResponse;
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposal;
 import com.dementor.domain.mentorapplyproposal.entity.MentorApplyProposalStatus;
 import com.dementor.domain.mentorapplyproposal.repository.MentorApplyProposalRepository;
-
+import com.dementor.domain.postattachment.entity.PostAttachment;
+import com.dementor.domain.postattachment.repository.PostAttachmentRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +32,7 @@ public class AdminMentorApplymentService {
 	private final MentorRepository mentorRepository;
 	private final MemberRepository memberRepository;
 	private final MentorApplyProposalRepository mentorApplyProposalRepository;
+	private final PostAttachmentRepository postAttachmentRepository;
 
 	public Page<ApplymentResponse> findAllApplyment(Pageable pageable) {
 		return mentorApplyProposalRepository.findAll(pageable)
@@ -42,13 +45,9 @@ public class AdminMentorApplymentService {
 			.orElseThrow(() -> new EntityNotFoundException("지원서를 찾을 수 없습니다."));
 
 		// 첨부파일 목록 조회
-		//        List<PostAttachment> attachments = attachmentRepository.findByApplymentId(memberId);
+		List<PostAttachment> attachments = postAttachmentRepository.findByMentorApplyProposalId(applyment.getId());
 
-		return ApplymentDetailResponse.from(
-			applyment
-			//                job
-			//                attachments
-		);
+		return ApplymentDetailResponse.from(applyment, attachments);
 	}
 
 	public ApplymentApprovalResponse approveApplyment(Long memberId) {

--- a/src/main/java/com/dementor/domain/mentorapplyproposal/service/AdminMentorApplymentService.java
+++ b/src/main/java/com/dementor/domain/mentorapplyproposal/service/AdminMentorApplymentService.java
@@ -36,7 +36,7 @@ public class AdminMentorApplymentService {
 
 	public Page<ApplymentResponse> findAllApplyment(Pageable pageable) {
 		return mentorApplyProposalRepository.findAll(pageable)
-			.map(application -> ApplymentResponse.from(application, application.getJob()));
+			.map(ApplymentResponse::from);
 	}
 
 	public ApplymentDetailResponse findOneApplyment(Long memberId) {

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
@@ -1,11 +1,7 @@
 package com.dementor.domain.mentoreditproposal.dto;
 
-import com.dementor.domain.mentorapplyproposal.dto.response.AttachmentInfo;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
-import com.dementor.domain.postattachment.entity.PostAttachment;
-
-import java.util.List;
 
 public record MentorEditFindAllRenewalResponse(
 	Long id,
@@ -16,12 +12,10 @@ public record MentorEditFindAllRenewalResponse(
 	Integer career,
 	String currentCompany,
 	String introduction,
-	String jobName,
-	List<AttachmentInfo> attachments
+	String jobName
 ) {
 	public static MentorEditFindAllRenewalResponse from(
-			MentorEditProposal mentorEditProposal,
-			List<PostAttachment> attachments
+			MentorEditProposal mentorEditProposal
 	) {
 		return new MentorEditFindAllRenewalResponse(
 			mentorEditProposal.getId(),
@@ -32,10 +26,7 @@ public record MentorEditFindAllRenewalResponse(
 			mentorEditProposal.getCareer(),
 			mentorEditProposal.getCurrentCompany(),
 			mentorEditProposal.getIntroduction(),
-			mentorEditProposal.getJob().getName(),
-			attachments.stream()
-					.map(AttachmentInfo::from)
-					.toList()
+			mentorEditProposal.getJob().getName()
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
@@ -16,6 +16,7 @@ public record MentorEditFindAllRenewalResponse(
 	Integer career,
 	String currentCompany,
 	String introduction,
+	String jobName,
 	List<AttachmentInfo> attachments
 ) {
 	public static MentorEditFindAllRenewalResponse from(
@@ -31,6 +32,7 @@ public record MentorEditFindAllRenewalResponse(
 			mentorEditProposal.getCareer(),
 			mentorEditProposal.getCurrentCompany(),
 			mentorEditProposal.getIntroduction(),
+			mentorEditProposal.getJob().getName(),
 			attachments.stream()
 					.map(AttachmentInfo::from)
 					.toList()

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditFindAllRenewalResponse.java
@@ -1,7 +1,11 @@
 package com.dementor.domain.mentoreditproposal.dto;
 
+import com.dementor.domain.mentorapplyproposal.dto.response.AttachmentInfo;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
+import com.dementor.domain.postattachment.entity.PostAttachment;
+
+import java.util.List;
 
 public record MentorEditFindAllRenewalResponse(
 	Long id,
@@ -11,9 +15,13 @@ public record MentorEditFindAllRenewalResponse(
 	String createdAt,
 	Integer career,
 	String currentCompany,
-	String introduction
+	String introduction,
+	List<AttachmentInfo> attachments
 ) {
-	public static MentorEditFindAllRenewalResponse from(MentorEditProposal mentorEditProposal) {
+	public static MentorEditFindAllRenewalResponse from(
+			MentorEditProposal mentorEditProposal,
+			List<PostAttachment> attachments
+	) {
 		return new MentorEditFindAllRenewalResponse(
 			mentorEditProposal.getId(),
 			mentorEditProposal.getMember().getId(),
@@ -22,7 +30,10 @@ public record MentorEditFindAllRenewalResponse(
 			mentorEditProposal.getCreatedAt().toString(),
 			mentorEditProposal.getCareer(),
 			mentorEditProposal.getCurrentCompany(),
-			mentorEditProposal.getIntroduction()
+			mentorEditProposal.getIntroduction(),
+			attachments.stream()
+					.map(AttachmentInfo::from)
+					.toList()
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
@@ -12,6 +12,7 @@ public record MentorEditUpdateRenewalResponse(
 	Long memberId,
 	MentorEditProposalStatus status,
 	String modifiedAt,
+	String jobName,
 	List<AttachmentInfo> attachments
 ) {
 	public static MentorEditUpdateRenewalResponse from(
@@ -23,6 +24,7 @@ public record MentorEditUpdateRenewalResponse(
 			mentorEditProposal.getMember().getId(),
 			mentorEditProposal.getStatus(),
 			mentorEditProposal.getModifiedAt().toString(),
+			mentorEditProposal.getJob().getName(),
 			attachments.stream()
 					.map(AttachmentInfo::from)
 					.toList()

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
@@ -1,21 +1,31 @@
 package com.dementor.domain.mentoreditproposal.dto;
 
+import com.dementor.domain.mentorapplyproposal.dto.response.AttachmentInfo;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
+import com.dementor.domain.postattachment.entity.PostAttachment;
+
+import java.util.List;
 
 public record MentorEditUpdateRenewalResponse(
-
 	Long id,
 	Long memberId,
 	MentorEditProposalStatus status,
-	String modifiedAt
+	String modifiedAt,
+	List<AttachmentInfo> attachments
 ) {
-	public static MentorEditUpdateRenewalResponse from(MentorEditProposal mentorEditProposal) {
+	public static MentorEditUpdateRenewalResponse from(
+			MentorEditProposal mentorEditProposal,
+			List<PostAttachment> attachments
+	) {
 		return new MentorEditUpdateRenewalResponse(
 			mentorEditProposal.getId(),
 			mentorEditProposal.getMember().getId(),
 			mentorEditProposal.getStatus(),
-			mentorEditProposal.getModifiedAt().toString()
+			mentorEditProposal.getModifiedAt().toString(),
+			attachments.stream()
+					.map(AttachmentInfo::from)
+					.toList()
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/dto/MentorEditUpdateRenewalResponse.java
@@ -1,33 +1,24 @@
 package com.dementor.domain.mentoreditproposal.dto;
 
-import com.dementor.domain.mentorapplyproposal.dto.response.AttachmentInfo;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
-import com.dementor.domain.postattachment.entity.PostAttachment;
-
-import java.util.List;
 
 public record MentorEditUpdateRenewalResponse(
 	Long id,
 	Long memberId,
 	MentorEditProposalStatus status,
 	String modifiedAt,
-	String jobName,
-	List<AttachmentInfo> attachments
+	String jobName
 ) {
 	public static MentorEditUpdateRenewalResponse from(
-			MentorEditProposal mentorEditProposal,
-			List<PostAttachment> attachments
+			MentorEditProposal mentorEditProposal
 	) {
 		return new MentorEditUpdateRenewalResponse(
 			mentorEditProposal.getId(),
 			mentorEditProposal.getMember().getId(),
 			mentorEditProposal.getStatus(),
 			mentorEditProposal.getModifiedAt().toString(),
-			mentorEditProposal.getJob().getName(),
-			attachments.stream()
-					.map(AttachmentInfo::from)
-					.toList()
+			mentorEditProposal.getJob().getName()
 		);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentoreditproposal/service/AdminModificationService.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/service/AdminModificationService.java
@@ -9,7 +9,6 @@ import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
 import com.dementor.domain.mentoreditproposal.repository.AdminModificationRepository;
 import com.dementor.domain.mentoreditproposal.repository.MentorEditProposalRepository;
-import com.dementor.domain.postattachment.entity.PostAttachment;
 import com.dementor.domain.postattachment.repository.PostAttachmentRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
@@ -17,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +31,7 @@ public class AdminModificationService {
 		// TODO : Pending 상태인것만 찾고 싶으면 추가 조건문 작성 필요
 		mentorEditProposalPage = adminModificationRepository.findAll(pageable);
 
-		return mentorEditProposalPage.map(proposal -> {
-			List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(proposal.getId());
-			return MentorEditFindAllRenewalResponse.from(proposal, attachments);
-		});
+		return mentorEditProposalPage.map(MentorEditFindAllRenewalResponse::from);
 	}
 
 	public MentorEditUpdateRenewalResponse approveMentorUpdate(Long memberId) {
@@ -59,8 +53,7 @@ public class AdminModificationService {
 		mentorEditProposalRepository.save(mentorEditProposal);
 		mentorRepository.save(mentor);
 
-		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(mentorEditProposal.getId());
-		return MentorEditUpdateRenewalResponse.from(mentorEditProposal, attachments);
+		return MentorEditUpdateRenewalResponse.from(mentorEditProposal);
 	}
 
 	@Transactional
@@ -77,7 +70,6 @@ public class AdminModificationService {
 		mentorEditProposalRepository.save(mentorEditProposal);
 		mentorRepository.save(mentor);
 
-		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(mentorEditProposal.getId());
-		return MentorEditUpdateRenewalResponse.from(mentorEditProposal, attachments);
+		return MentorEditUpdateRenewalResponse.from(mentorEditProposal);
 	}
 }

--- a/src/main/java/com/dementor/domain/mentoreditproposal/service/AdminModificationService.java
+++ b/src/main/java/com/dementor/domain/mentoreditproposal/service/AdminModificationService.java
@@ -9,16 +9,16 @@ import com.dementor.domain.mentoreditproposal.entity.MentorEditProposal;
 import com.dementor.domain.mentoreditproposal.entity.MentorEditProposalStatus;
 import com.dementor.domain.mentoreditproposal.repository.AdminModificationRepository;
 import com.dementor.domain.mentoreditproposal.repository.MentorEditProposalRepository;
-
+import com.dementor.domain.postattachment.entity.PostAttachment;
+import com.dementor.domain.postattachment.repository.PostAttachmentRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import static java.time.LocalTime.now;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +26,7 @@ public class AdminModificationService {
 	private final AdminModificationRepository adminModificationRepository;
 	private final MentorEditProposalRepository mentorEditProposalRepository;
 	private final MentorRepository mentorRepository;
+	private final PostAttachmentRepository postAttachmentRepository;
 
 	public Page<MentorEditFindAllRenewalResponse> findAllModificationRequest(Pageable pageable) {
 		Page<MentorEditProposal> mentorEditProposalPage;
@@ -33,7 +34,10 @@ public class AdminModificationService {
 		// TODO : Pending 상태인것만 찾고 싶으면 추가 조건문 작성 필요
 		mentorEditProposalPage = adminModificationRepository.findAll(pageable);
 
-		return mentorEditProposalPage.map(MentorEditFindAllRenewalResponse::from);
+		return mentorEditProposalPage.map(proposal -> {
+			List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(proposal.getId());
+			return MentorEditFindAllRenewalResponse.from(proposal, attachments);
+		});
 	}
 
 	public MentorEditUpdateRenewalResponse approveMentorUpdate(Long memberId) {
@@ -55,15 +59,8 @@ public class AdminModificationService {
 		mentorEditProposalRepository.save(mentorEditProposal);
 		mentorRepository.save(mentor);
 
-		// MentorEditUpdateRenewalResponse 객체 생성
-		MentorEditUpdateRenewalResponse response = new MentorEditUpdateRenewalResponse(
-			mentor.getId(),
-			memberId,
-			mentorEditProposal.getStatus(),
-			now().toString()
-		);
-
-		return response;
+		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(mentorEditProposal.getId());
+		return MentorEditUpdateRenewalResponse.from(mentorEditProposal, attachments);
 	}
 
 	@Transactional
@@ -80,14 +77,7 @@ public class AdminModificationService {
 		mentorEditProposalRepository.save(mentorEditProposal);
 		mentorRepository.save(mentor);
 
-		// MentorEditUpdateRenewalResponse 객체 생성
-		MentorEditUpdateRenewalResponse response = new MentorEditUpdateRenewalResponse(
-			mentor.getId(),
-			memberId,
-			mentorEditProposal.getStatus(),
-			now().toString()
-		);
-
-		return response;
+		List<PostAttachment> attachments = postAttachmentRepository.findByMentorEditProposalId(mentorEditProposal.getId());
+		return MentorEditUpdateRenewalResponse.from(mentorEditProposal, attachments);
 	}
 }

--- a/src/main/java/com/dementor/global/websocket/StompRabbitMqBrokerConfig.java
+++ b/src/main/java/com/dementor/global/websocket/StompRabbitMqBrokerConfig.java
@@ -31,8 +31,8 @@ public class StompRabbitMqBrokerConfig implements WebSocketMessageBrokerConfigur
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 		registry
-			.setApplicationDestinationPrefixes("/app")
-			.enableStompBrokerRelay("/topic")
+			.setApplicationDestinationPrefixes("/app")// 클-> 서버
+			.enableStompBrokerRelay("/topic") //서버->클 브로드캐스트 경로
 			.setRelayHost(rabbitmqHost)
 			.setRelayPort(61613)
 			.setClientLogin(rabbitmqUsername)


### PR DESCRIPTION
## ✨ 변경 사항
- 멘토 정보 수정 요청 조회(상세보기), 멘토 지원 데이터 상세조회에만 fileURL, fileName 보여주도록 수정
- 다른 조회 dto에는 JobName 직무 보여주도록 수정
- 멘토 정보 수정 요청 조회(상세보기)에 관리자 권한도 설정

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련된 테스트를 수행했는지 확인
- [x] 리뷰어가 이해하기 쉽도록 설명을 추가했는지 확인

## 🔗 관련 이슈
- 관련 이슈 번호: #151 