### PR TITLE
[REFACTOR]: 멘토 정보 수정 요청 조회에 상세보기가 가능하도록 수정

### DIFF
--- a/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
+++ b/src/main/java/com/dementor/domain/mentor/controller/MentorController.java
@@ -168,6 +168,7 @@ public class MentorController {
 		@RequestParam(required = false) String status,
 		@RequestParam(required = false, defaultValue = "1") Integer page,
 		@RequestParam(required = false, defaultValue = "10") Integer size,
+		@RequestParam(required = false) Long proposalId,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 
 		try {
@@ -197,7 +198,7 @@ public class MentorController {
 			}
 
 			MentorChangeRequest.ModificationRequestParams params =
-				new MentorChangeRequest.ModificationRequestParams(status, page, size);
+					new MentorChangeRequest.ModificationRequestParams(status, page, size, proposalId);
 			MentorChangeResponse.ChangeListResponse response =
 				mentorService.getModificationRequests(memberId, params);
 

--- a/src/main/java/com/dementor/domain/mentor/dto/request/MentorChangeRequest.java
+++ b/src/main/java/com/dementor/domain/mentor/dto/request/MentorChangeRequest.java
@@ -10,11 +10,17 @@ public class MentorChangeRequest {
 		Integer page,
 
 		@Min(value = 1, message = "페이지 크기는 1 이상이어야 합니다.")
-		Integer size
+		Integer size,
+		Long proposalId
 	) {
+		// 기존 생성자
+		public ModificationRequestParams(String status, Integer page, Integer size) {
+			this(status, page, size, null);
+		}
+
 		// 기본값을 설정하는 정적 팩토리 메서드
 		public static ModificationRequestParams defaultParams() {
-			return new ModificationRequestParams(null, 1, 10);
+			return new ModificationRequestParams(null, 1, 10, null);
 		}
 	}
 }

--- a/src/main/java/com/dementor/domain/mentor/exception/MentorErrorCode.java
+++ b/src/main/java/com/dementor/domain/mentor/exception/MentorErrorCode.java
@@ -17,7 +17,8 @@ public enum MentorErrorCode {
 	INVALID_STATUS_PARAM(HttpStatus.BAD_REQUEST, "유효하지 않은 상태 파라미터입니다."),
 	UNAUTHORIZED_MODIFICATION(HttpStatus.FORBIDDEN, "해당 멘토 정보를 수정할 권한이 없습니다."),
 	UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "해당 멘토 정보에 접근할 권한이 없습니다."),
-	JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "직무 정보를 찾을 수 없습니다.");
+	JOB_NOT_FOUND(HttpStatus.NOT_FOUND, "직무 정보를 찾을 수 없습니다."),
+	EDIT_PROPOSAL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 수정 요청을 찾을 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;


### PR DESCRIPTION
## ✨ 변경 사항
- 멘토 정보 수정 요청 조회에 상세보기가 가능하도록 RequestParam에 proposalId 추가

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하는지 확인
- [x] 관련된 테스트를 수행했는지 확인 (swagger 테스트)
- [x] 리뷰어가 이해하기 쉽도록 설명을 추가했는지 확인

## 🔗 관련 이슈
- 관련 이슈 번호: #164 